### PR TITLE
fix: remove unnecessary authentication method

### DIFF
--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -1,5 +1,4 @@
 class StocksController < ApplicationController
-  before_action :authenticate_user!
   def trade
     @stock = Stock.find_by(symbol: get_stock[:symbol])
     @stock ||= Stock.create(symbol: get_stock[:symbol], company_name: get_stock[:company_name])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!
   before_action :admin_only, except: [:portfolio]
   before_action :find_user, only: %i[show edit update destroy approve portfolio]
   before_action :user_type_options, only: %i[new create edit update]


### PR DESCRIPTION
```ruby
before_action authenticate_user!
```
is already called on the application controller so no need to call it anywhere.